### PR TITLE
Add `#![no_std]`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,24 @@ jobs:
       - run: cargo build
       - run: cargo test
       - run: cargo doc
+
+  build-cross:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - thumbv7m-none-eabi
+        toolchain:
+          - stable
+          - nightly
+    name: Cross-build ${{ matrix.toolchain }} for ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - run: rustup target add ${{ matrix.target }}
+      - run: cargo build --target ${{ matrix.target }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ assert_eq!("test, 10, b, true", concat_with_comma!("test", 10, 'b', true));
 assert_eq!("test:10:b:true", concat_with_colon!("test", 10, 'b', true));
 ```
 */
+#![no_std]
 
 /**
 Concatenates literals into a static string slice.


### PR DESCRIPTION
Makes the crate compatible with no-std targets.